### PR TITLE
fix: Lightning tab never loads with LND backend (wrong macaroon path)

### DIFF
--- a/startos/actions/enableLightning.ts
+++ b/startos/actions/enableLightning.ts
@@ -1,6 +1,6 @@
 import { configJson } from '../file-models/mempool-config.json'
 import { sdk } from '../sdk'
-import { lndMountpoint, clnMountpoint } from '../utils'
+import { clnMountpoint, lndCertPath, lndMacaroonPath } from '../utils'
 import { i18n } from '../i18n'
 const { InputSpec, Value } = sdk
 
@@ -54,8 +54,8 @@ export const enableLightning = sdk.Action.withInput(
         await configJson.merge(effects, {
           LIGHTNING: { ENABLED: true, BACKEND: 'lnd' },
           LND: {
-            TLS_CERT_PATH: `${lndMountpoint}/tls.cert`,
-            MACAROON_PATH: `${lndMountpoint}/readonly.macaroon`,
+            TLS_CERT_PATH: lndCertPath,
+            MACAROON_PATH: lndMacaroonPath,
           },
         })
         break

--- a/startos/file-models/mempool-config.json.ts
+++ b/startos/file-models/mempool-config.json.ts
@@ -2,8 +2,9 @@ import { FileHelper, z } from '@start9labs/start-sdk'
 import { sdk } from '../sdk'
 import {
   btcMountpoint,
-  lndMountpoint,
   clnMountpoint,
+  lndCertPath,
+  lndMacaroonPath,
   PROFILES,
   DEFAULT_PROFILE,
 } from '../utils'
@@ -131,12 +132,8 @@ const lightningSection = z.object({
 
 const lndSection = z.object({
   // enforced
-  TLS_CERT_PATH: z
-    .literal(`${lndMountpoint}/tls.cert`)
-    .catch(`${lndMountpoint}/tls.cert`),
-  MACAROON_PATH: z
-    .literal(`${lndMountpoint}/readonly.macaroon`)
-    .catch(`${lndMountpoint}/readonly.macaroon`),
+  TLS_CERT_PATH: z.literal(lndCertPath).catch(lndCertPath),
+  MACAROON_PATH: z.literal(lndMacaroonPath).catch(lndMacaroonPath),
   REST_API_URL: z
     .literal('https://lnd.startos:8080')
     .catch('https://lnd.startos:8080'),

--- a/startos/utils.ts
+++ b/startos/utils.ts
@@ -16,6 +16,9 @@ export const btcMountpoint = '/mnt/bitcoind'
 export const lndMountpoint = '/mnt/lnd'
 export const clnMountpoint = '/mnt/cln'
 
+export const lndCertPath = `${lndMountpoint}/tls.cert`
+export const lndMacaroonPath = `${lndMountpoint}/data/chain/bitcoin/mainnet/readonly.macaroon`
+
 // Performance profile presets. POLL_RATE_MS is the main-loop period;
 // MEMPOOL_BLOCKS_AMOUNT is the depth of the Rust GBT projection. Both
 // scale backend CPU roughly linearly. Single source of truth — referenced

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,18 @@
 import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '3.3.1:10',
+  version: '3.3.1:11',
   releaseNotes: {
     en_US:
-      'The web interface now starts only after the backend API is ready, so it no longer briefly serves before the backend is reachable.',
+      'Fixes the Lightning tab never loading with an LND backend (corrected the read-only macaroon path).',
     es_ES:
-      'La interfaz web ahora se inicia solo después de que la API del backend esté lista, de modo que ya no se sirve brevemente antes de que el backend sea accesible.',
+      'Corrige que la pestaña Lightning nunca cargara con un backend LND (se corrigió la ruta de la macaroon de solo lectura).',
     de_DE:
-      'Die Weboberfläche startet jetzt erst, wenn die Backend-API bereit ist, und wird nicht mehr kurzzeitig ausgeliefert, bevor das Backend erreichbar ist.',
+      'Behebt, dass der Lightning-Tab mit einem LND-Backend nie geladen wurde (Pfad der Read-only-Macaroon korrigiert).',
     pl_PL:
-      'Interfejs sieciowy uruchamia się teraz dopiero po gotowości API backendu, więc nie jest już przez chwilę serwowany, zanim backend stanie się osiągalny.',
+      'Naprawia brak ładowania zakładki Lightning przy backendzie LND (poprawiono ścieżkę macaroon tylko do odczytu).',
     fr_FR:
-      'L’interface web ne démarre désormais qu’une fois l’API du backend prête, et n’est donc plus servie brièvement avant que le backend soit joignable.',
+      "Corrige l'onglet Lightning qui ne se chargeait jamais avec un backend LND (chemin de la macaroon en lecture seule corrigé).",
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Problem

Multiple users report Mempool's **Lightning tab stays in a perpetual loading state** with a healthy LND running and selected on default settings.

## Root cause

LND (`lnd-startos`) stores its macaroons under `data/chain/bitcoin/mainnet/` inside its `main` volume — the same layout `lnd-startos`'s own `interfaces.ts` reads from (`/media/startos/volumes/main/data/chain/bitcoin/mainnet/admin.macaroon`). The `tls.cert`, by contrast, is written at the volume root.

Mempool mounts LND's `main` volume at `/mnt/lnd` but pointed `MACAROON_PATH` at the **volume root**:

| File | was | actual location |
|------|-----|-----------------|
| `tls.cert` | `/mnt/lnd/tls.cert` ✓ | volume root — correct |
| `readonly.macaroon` | `/mnt/lnd/readonly.macaroon` ✗ | `/mnt/lnd/data/chain/bitcoin/mainnet/readonly.macaroon` |

The backend couldn't read the macaroon, so the LND REST connection never initialized and the Lightning tab loaded forever.

CLN was checked and is **correct** (`<main>/bitcoin/lightning-rpc`, mounted via subpath `bitcoin`) — this was an LND-only bug.

## Fix

- Centralize the LND cert/macaroon paths in `utils.ts` (`lndCertPath`, `lndMacaroonPath`) and point the macaroon at the real `data/chain/bitcoin/mainnet/readonly.macaroon` path.
- Use those constants in both the config file model (enforced `z.literal`) and the `enable-lightning` action.

## Existing installs

Self-heal on the first start after upgrade: `MACAROON_PATH` is an enforced `z.literal(...).catch(...)`, so a read coerces the stale path to the corrected one, and `seedFiles`' `configJson.merge(effects, {})` (run on every non-install init) rewrites the on-disk config. No explicit migration required; the carried-forward 0.3.5.1 migration is untouched.

## Release

Bumps to **3.3.1:3**. Built clean for `x86_64` and `aarch64`; `tsc --noEmit` passes.