### PR TITLE
fix: reduce low-RAM OOM risk (heap cap + Lightning warning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 | Container | Entrypoint                                                  | Notes                                                                                                                                                                                                                                      |
 | --------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Frontend  | Upstream `docker-entrypoint.sh` (via `sdk.useEntrypoint()`) | `LIGHTNING=true` injected when a Lightning node is configured                                                                                                                                                                              |
-| Backend   | Custom: `node /backend/package/index.js`                    | Runs as `root`; `NODE_OPTIONS=--max-old-space-size=<dynamic>` — sized to (host RAM − 6 GB reserve for Bitcoin/indexer/LN/OS). Baseline: 1/8 of the remainder, clamped 2048–8192 MB. With any indexing toggle on: 1/4, clamped 4096–8192 MB |
+| Backend   | Custom: `node /backend/package/index.js`                    | Runs as `root`; `NODE_OPTIONS=--max-old-space-size=<dynamic>` — sized to (host RAM − 6 GB reserve for Bitcoin/indexer/LN/OS). Baseline: 1/8 of the remainder, clamped 2048–8192 MB; on hosts with <10 GB total RAM the baseline is pinned to 1024 MB so the backend can't balloon and OOM-kill a sibling. With any indexing toggle on: 1/4, clamped 4096–8192 MB |
 | MariaDB   | Upstream `docker-entrypoint.sh` (via `sdk.useEntrypoint()`) | `--bind-address=127.0.0.1` enforces loopback-only listener                                                                                                                                                                                 |
 
 ## Volume and Data Layout
@@ -161,6 +161,8 @@ Selecting an indexer enables address search and transaction history features. Se
 
 When enabled, configures the `LIGHTNING` and `LND`/`CLIGHTNING` sections of the configuration and mounts the selected Lightning node's volume.
 
+On hosts with less than ~16 GB of total RAM (threshold: 15 GiB) the action carries a confirmation **warning**: the Lightning network-graph sync is memory-intensive, and running it alongside Bitcoin Core and an Electrum indexer on a low-memory device can push the system into out-of-memory crashes. It is a warning, not a hard gate — the user can still proceed.
+
 ### Indexing and Performance
 
 - **Name:** Indexing and Performance
@@ -191,7 +193,7 @@ Sets `MEMPOOL.POLL_RATE_MS`, `MEMPOOL.MEMPOOL_BLOCKS_AMOUNT`, `STATISTICS.ENABLE
 **Indexing.** All four indexing toggles are off by default, matching upstream. Enabling any of them triggers a historical backfill on the next service restart, which can take several hours and consume significant disk space.
 
 - **RAM requirement:** The action rejects any submission with at least one indexing toggle on when the host has less than ~16 GB of total RAM (threshold: 15 GiB). Backend indexing competes with Bitcoin Core's dbcache, the selected Electrum indexer, and any Lightning node, so enabling it on a low-memory device is likely to OOM one of the services in the stack.
-- **Heap behavior:** When any indexing toggle is on, the backend's V8 heap is raised on the next restart so indexing has room to work. The formula subtracts a 6 GB reserve for the co-resident stack (Bitcoin Core, the selected indexer, any Lightning node, StartOS) and then takes 1/4 of the remainder, clamped 4–8 GB. A 16 GB box gets a 4 GB heap; a 32 GB box gets ~6.5 GB; ≥40 GB gets the 8 GB max.
+- **Heap behavior:** When any indexing toggle is on, the backend's V8 heap is raised on the next restart so indexing has room to work. The formula subtracts a 6 GB reserve for the co-resident stack (Bitcoin Core, the selected indexer, any Lightning node, StartOS) and then takes 1/4 of the remainder, clamped 4–8 GB. A 16 GB box gets a 4 GB heap; a 32 GB box gets ~6.5 GB; ≥40 GB gets the 8 GB max. With indexing off, the baseline heap is 1/8 of the remainder clamped 2–8 GB, except on hosts with <10 GB total RAM where it is pinned to 1 GB — on an 8 GB box the 2 GB floor exceeds free RAM and lets the backend grow until the kernel OOM-kills a sibling service (Fulcrum, in observed reports), so the tighter cap keeps Mempool's footprint bounded.
 
 ## Backups and Restore
 

--- a/instructions.md
+++ b/instructions.md
@@ -30,7 +30,7 @@ Open the **Web UI** interface to reach Mempool. The home page shows the live mem
 ### Actions
 
 - **Select Indexer** — switch the Electrum backend between Fulcrum and Electrs. Mempool's dependency set updates accordingly.
-- **Enable Lightning** — choose LND, Core Lightning, or none for the Lightning tab's data source. The selected node is mounted read-only.
+- **Enable Lightning** — choose LND, Core Lightning, or none for the Lightning tab's data source. The selected node is mounted read-only. On systems with less than 16 GB of RAM the action shows a warning before enabling: the Lightning network sync is memory-hungry, and turning it on alongside Bitcoin Core and your indexer can tip a low-memory box into out-of-memory crashes.
 - **Indexing and Performance** — tune backend behavior on a single form:
   - **Performance Profile** — pick **Low-CPU** (default; polls bitcoind every 8s, projects 4 future blocks), **Balanced** (4s / 6 blocks), or **Responsive** (2s / 8 blocks; highest CPU). The Mempool backend rebuilds its block projection on every poll, so this is the main lever for CPU usage on low-power devices.
   - **Enable Statistics** — leave on (default) for the tx/s and vbytes/s dashboard charts; turn off to skip the 1 Hz sampler and periodic MariaDB writes.
@@ -42,3 +42,4 @@ Open the **Web UI** interface to reach Mempool. The home page shows the live mem
 - **Electrum backend only.** The Esplora backend is not used.
 - **One indexer and one Lightning node at a time.** You cannot run Fulcrum and Electrs, or LND and CLN, simultaneously against Mempool.
 - **No paid acceleration, no MaxMind GeoIP, no Redis, no Stratum, no replication** — these upstream features are deliberately disabled.
+- **Memory.** Mempool runs alongside Bitcoin Core, an Electrum indexer, and (optionally) a Lightning node, all of which are memory-hungry. On an 8 GB system this stack is tight: the backend's heap is capped tighter to leave room, but enabling Lightning and/or other heavy services on the same box can still trigger out-of-memory crashes. 16 GB or more is recommended if you want Lightning or indexing.

--- a/startos/actions/enableLightning.ts
+++ b/startos/actions/enableLightning.ts
@@ -1,8 +1,17 @@
+import { totalmem } from 'os'
 import { configJson } from '../file-models/mempool-config.json'
 import { sdk } from '../sdk'
 import { clnMountpoint, lndCertPath, lndMacaroonPath } from '../utils'
 import { i18n } from '../i18n'
 const { InputSpec, Value } = sdk
+
+// 15 GiB floor to cover 16 GB devices that report slightly less than 16 * 2^30.
+const lowRamWarning =
+  totalmem() < 15 * 1024 ** 3
+    ? i18n(
+        'Lightning network data is memory-intensive. Running it alongside Bitcoin Core and an Electrum indexer on a system with less than 16 GB of RAM can trigger out-of-memory crashes that take down Mempool or one of its dependencies. Enable only if you have RAM headroom to spare.',
+      )
+    : null
 
 export const lightningInputSpec = InputSpec.of({
   lightning: Value.select({
@@ -28,7 +37,7 @@ export const enableLightning = sdk.Action.withInput(
     description: i18n(
       'Use this setting to select the Lightning node used to serve network data to the Lightning tab in Mempool',
     ),
-    warning: null,
+    warning: lowRamWarning,
     allowedStatuses: 'any',
     group: null,
     visibility: 'enabled',

--- a/startos/i18n/dictionaries/default.ts
+++ b/startos/i18n/dictionaries/default.ts
@@ -49,6 +49,7 @@ const dict = {
   'Collects mempool statistics (transactions per second, vbytes per second) for the dashboard charts. Disabling stops the 1 Hz sampler and the periodic statistics writes to MariaDB, reducing background CPU and disk I/O on low-power devices.': 50,
   'Indexing and Performance': 51,
   'Tune backend behavior: poll/projection profile, mempool statistics, and optional indexing features. Changes apply on the next service restart. Enabling any indexing toggle triggers a historical backfill on the next start, which can take several hours and consume significant disk space; indexing requires at least 16 GB of system RAM and is rejected on lower-memory devices.': 52,
+  'Lightning network data is memory-intensive. Running it alongside Bitcoin Core and an Electrum indexer on a system with less than 16 GB of RAM can trigger out-of-memory crashes that take down Mempool or one of its dependencies. Enable only if you have RAM headroom to spare.': 53,
 } as const
 
 export type I18nKey = keyof typeof dict

--- a/startos/i18n/dictionaries/translations.ts
+++ b/startos/i18n/dictionaries/translations.ts
@@ -50,6 +50,7 @@ export default {
     50: 'Recopila estadisticas de mempool (transacciones por segundo, vbytes por segundo) para los graficos del panel. Desactivarlo detiene el muestreador de 1 Hz y las escrituras periodicas a MariaDB, reduciendo el uso de CPU en segundo plano y la E/S de disco en dispositivos de baja potencia.',
     51: 'Indexacion y rendimiento',
     52: 'Ajusta el comportamiento del backend: perfil de consulta/proyeccion, estadisticas de mempool y funciones opcionales de indexacion. Los cambios se aplican al siguiente reinicio del servicio. Activar cualquier opcion de indexacion desencadena un llenado historico en el siguiente arranque, que puede tardar varias horas y consumir espacio de disco significativo; la indexacion requiere al menos 16 GB de RAM y se rechaza en dispositivos con menos memoria.',
+    53: 'Los datos de la red Lightning consumen mucha memoria. Ejecutarlos junto con Bitcoin Core y un indexador Electrum en un sistema con menos de 16 GB de RAM puede provocar fallos por falta de memoria que tumben Mempool o una de sus dependencias. Active esta opcion solo si dispone de memoria de sobra.',
   },
   de_DE: {
     0: 'Mempool wird gestartet',
@@ -100,6 +101,7 @@ export default {
     50: 'Sammelt Mempool-Statistiken (Transaktionen pro Sekunde, vBytes pro Sekunde) fuer die Dashboard-Diagramme. Beim Deaktivieren wird der 1-Hz-Sampler gestoppt und die periodischen Statistik-Schreibvorgaenge in MariaDB entfallen, was die Hintergrund-CPU-Last und die Festplatten-E/A auf leistungsschwachen Geraeten reduziert.',
     51: 'Indexierung und Leistung',
     52: 'Optimiert das Verhalten des Backends: Abfrage-/Projektionsprofil, Mempool-Statistik und optionale Indexierungsfunktionen. Aenderungen werden beim naechsten Dienstneustart wirksam. Das Aktivieren einer Indexierungsoption loest beim naechsten Start einen historischen Abgleich aus, der mehrere Stunden dauern und viel Speicherplatz beanspruchen kann; die Indexierung erfordert mindestens 16 GB Arbeitsspeicher und wird auf Geraeten mit weniger Speicher abgelehnt.',
+    53: 'Lightning-Netzwerkdaten sind speicherintensiv. Werden sie zusammen mit Bitcoin Core und einem Electrum-Indexer auf einem System mit weniger als 16 GB Arbeitsspeicher ausgefuehrt, kann dies zu Speichermangel-Abstuerzen fuehren, die Mempool oder eine seiner Abhaengigkeiten lahmlegen. Aktivieren Sie dies nur, wenn Sie genug freien Arbeitsspeicher haben.',
   },
   pl_PL: {
     0: 'Uruchamianie Mempool',
@@ -150,6 +152,7 @@ export default {
     50: 'Zbiera statystyki mempool (transakcje na sekunde, vbajty na sekunde) dla wykresow panelu. Wylaczenie zatrzymuje sampler 1 Hz i okresowe zapisy statystyk do MariaDB, zmniejszajac uzycie CPU w tle i operacje I/O dysku na urzadzeniach o niskiej mocy.',
     51: 'Indeksowanie i wydajnosc',
     52: 'Dostosowuje zachowanie backendu: profil odpytywania/projekcji, statystyki mempool i opcjonalne funkcje indeksowania. Zmiany sa stosowane przy nastepnym ponownym uruchomieniu uslugi. Wlaczenie dowolnej opcji indeksowania uruchomi historyczne uzupelnienie przy nastepnym starcie, co moze zajac wiele godzin i zuzyc znaczna ilosc miejsca na dysku; indeksowanie wymaga co najmniej 16 GB pamieci RAM i jest odrzucane na urzadzeniach z mniejsza iloscia pamieci.',
+    53: 'Dane sieci Lightning sa pamieciozerne. Uruchamianie ich razem z Bitcoin Core i indekserem Electrum w systemie z mniej niz 16 GB pamieci RAM moze powodowac awarie z powodu braku pamieci, ktore wylaczaja Mempool lub jedna z jego zaleznosci. Wlacz tylko, jesli masz zapas wolnej pamieci.',
   },
   fr_FR: {
     0: 'Demarrage de Mempool',
@@ -200,5 +203,6 @@ export default {
     50: "Collecte les statistiques mempool (transactions par seconde, vbytes par seconde) pour les graphiques du tableau de bord. Le desactiver arrete l'echantillonneur a 1 Hz et les ecritures periodiques en base MariaDB, reduisant l'utilisation CPU en arriere-plan et les E/S disque sur les appareils a faible puissance.",
     51: 'Indexation et performances',
     52: "Ajuste le comportement du backend : profil d'interrogation/projection, statistiques mempool et fonctionnalites d'indexation optionnelles. Les changements prennent effet au prochain redemarrage du service. L'activation de toute option d'indexation declenche un remplissage historique au prochain demarrage, qui peut prendre plusieurs heures et consommer un espace disque important ; l'indexation necessite au moins 16 Go de RAM et est rejetee sur les appareils disposant de moins de memoire.",
+    53: "Les donnees du reseau Lightning sont gourmandes en memoire. Les executer avec Bitcoin Core et un indexeur Electrum sur un systeme disposant de moins de 16 Go de RAM peut provoquer des plantages par manque de memoire qui font tomber Mempool ou l'une de ses dependances. N'activez cette option que si vous disposez de memoire libre en reserve.",
   },
 } satisfies Record<string, LangDict>

--- a/startos/main.ts
+++ b/startos/main.ts
@@ -31,10 +31,13 @@ export const main = sdk.setupMain(async ({ effects }) => {
   // Fulcrum/Electrs, LND/CLN, StartOS and OS overhead) before computing
   // our share. Indexing (audit/goggles/summaries/cpfp) is memory-hungry,
   // so when any of those toggles is on we raise the floor and share a
-  // larger fraction of the remaining host RAM.
+  // larger fraction of the remaining host RAM. On <=8 GB hosts the 2 GB
+  // baseline floor exceeds free RAM and lets RSS balloon until the kernel
+  // OOM-kills a sibling (e.g. Fulcrum), so we cap the backend tighter there.
   const RESERVED_MB = 6 * 1024
   const totalMB = Math.floor(totalmem() / (1024 * 1024))
   const effectiveMB = Math.max(0, totalMB - RESERVED_MB)
+  const lowRam = totalMB < 10 * 1024
   const anyIndexing =
     config.MEMPOOL.BLOCKS_SUMMARIES_INDEXING ||
     config.MEMPOOL.GOGGLES_INDEXING ||
@@ -42,7 +45,9 @@ export const main = sdk.setupMain(async ({ effects }) => {
     config.MEMPOOL.CPFP_INDEXING
   const backendMaxOldSpaceMB = anyIndexing
     ? Math.max(4096, Math.min(8192, Math.floor(effectiveMB / 4)))
-    : Math.max(2048, Math.min(8192, Math.floor(effectiveMB / 8)))
+    : lowRam
+      ? 1024
+      : Math.max(2048, Math.min(8192, Math.floor(effectiveMB / 8)))
 
   let backendMounts = sdk.Mounts.of()
     .mountVolume({

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,18 @@
 import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '3.3.1:11',
+  version: '3.3.1:12',
   releaseNotes: {
-    en_US:
-      'Fixes the Lightning tab never loading with an LND backend (corrected the read-only macaroon path).',
-    es_ES:
-      'Corrige que la pestaña Lightning nunca cargara con un backend LND (se corrigió la ruta de la macaroon de solo lectura).',
-    de_DE:
-      'Behebt, dass der Lightning-Tab mit einem LND-Backend nie geladen wurde (Pfad der Read-only-Macaroon korrigiert).',
-    pl_PL:
-      'Naprawia brak ładowania zakładki Lightning przy backendzie LND (poprawiono ścieżkę macaroon tylko do odczytu).',
-    fr_FR:
-      "Corrige l'onglet Lightning qui ne se chargeait jamais avec un backend LND (chemin de la macaroon en lecture seule corrigé).",
+    en_US: `- Cap the backend heap on hosts with 8 GB of RAM or less to reduce out-of-memory crashes.
+- Warn before enabling Lightning on hosts with less than 16 GB of RAM.`,
+    es_ES: `- Limita la memoria del backend en equipos con 8 GB de RAM o menos para reducir los fallos por falta de memoria.
+- Advierte antes de habilitar Lightning en equipos con menos de 16 GB de RAM.`,
+    de_DE: `- Begrenzt den Backend-Speicher auf Systemen mit 8 GB Arbeitsspeicher oder weniger, um Speichermangel-Abstuerze zu reduzieren.
+- Warnt vor dem Aktivieren von Lightning auf Systemen mit weniger als 16 GB Arbeitsspeicher.`,
+    pl_PL: `- Ogranicza pamiec backendu na urzadzeniach z 8 GB pamieci RAM lub mniej, aby zmniejszyc liczbe awarii z powodu braku pamieci.
+- Ostrzega przed wlaczeniem Lightning na urzadzeniach z mniej niz 16 GB pamieci RAM.`,
+    fr_FR: `- Limite la memoire du backend sur les hotes disposant de 8 Go de RAM ou moins pour reduire les plantages par manque de memoire.
+- Avertit avant d'activer Lightning sur les hotes disposant de moins de 16 Go de RAM.`,
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
Addresses [start-os#3326](https://github.com/Start9Labs/start-os/issues/3326): on an 8 GB ThinkCentre running Bitcoin Core (full) + Fulcrum + CLN + LNbits + Tor + Mempool, the box sits at ~95% RAM and the kernel OOM-killer fires. `dmesg` from the reporter confirms it — the casualty was **Fulcrum** (~1.87 GB RSS), which knocks out Mempool's Electrum connection and sends the api daemon into a health-check restart loop.

This is fundamentally an over-subscribed box (six memory-hungry services on 8 GB), but Mempool can degrade more gracefully and shrink its own footprint:

## Changes

- **Backend heap cap on low-RAM hosts.** With indexing off, the baseline `--max-old-space-size` floor was 2048 MB. On an 8 GB host the 6 GB reserve leaves ~1.6 GB free, yet we still permitted a 2 GB heap — so V8 wouldn't GC hard and RSS grew until the kernel killed a sibling. On hosts with <10 GB total RAM the baseline is now pinned to **1024 MB**, keeping Mempool's footprint bounded. Indexing-on and ≥10 GB behavior is unchanged.
- **Low-RAM warning on Enable Lightning.** On hosts with <16 GB RAM (15 GiB threshold, matching the indexing gate), the action now shows a confirmation warning that the Lightning network sync is memory-intensive and can trigger OOM crashes on a low-memory box. It's a warning, not a hard gate.
- Localized release notes + warning string (en/es/de/pl/fr); README + instructions updated.

## Notes

- Neither change "fixes" 8 GB + six services — that's a capacity problem — but both reduce the likelihood of the OOM cascade and set saner defaults.
- The deeper root cause (StartOS not enforcing per-service memory budgets, so the box thrashes) is outside this package.

Build verified: `make` produces both x86_64 and aarch64 s9pks at `v3.3.1:12`; `tsc --noEmit` clean.