### PR TITLE
fix: raise backend heap cap that crashed Mempool on low-RAM hosts (3.3.1:13)

### DIFF
--- a/startos/main.ts
+++ b/startos/main.ts
@@ -26,18 +26,16 @@ export const main = sdk.setupMain(async ({ effects }) => {
   const config = await configJson.read().const(effects)
   if (!config) throw new Error('Config file not found')
 
-  // V8 old-space heap for the mempool backend, scaled to host RAM.
-  // Reserve 6 GB for the co-resident stack (Bitcoin Core post-sync,
-  // Fulcrum/Electrs, LND/CLN, StartOS and OS overhead) before computing
-  // our share. Indexing (audit/goggles/summaries/cpfp) is memory-hungry,
-  // so when any of those toggles is on we raise the floor and share a
-  // larger fraction of the remaining host RAM. On <=8 GB hosts the 2 GB
-  // baseline floor exceeds free RAM and lets RSS balloon until the kernel
-  // OOM-kills a sibling (e.g. Fulcrum), so we cap the backend tighter there.
+  // V8 old-space heap for the mempool backend, scaled to host RAM. This is
+  // a ceiling, not a reservation: setting it below the backend's working set
+  // doesn't free RAM, it just turns a rare system-OOM into a guaranteed
+  // self-OOM. The backend needs >1 GB to restore its disk cache at startup,
+  // so an earlier 1 GB low-RAM cap crashed it on every boot even with system
+  // RAM free (start-os#3326). Keep a 2 GB non-indexing floor; indexing
+  // (audit/goggles/summaries/cpfp) is heavier, so raise the floor there.
   const RESERVED_MB = 6 * 1024
   const totalMB = Math.floor(totalmem() / (1024 * 1024))
   const effectiveMB = Math.max(0, totalMB - RESERVED_MB)
-  const lowRam = totalMB < 10 * 1024
   const anyIndexing =
     config.MEMPOOL.BLOCKS_SUMMARIES_INDEXING ||
     config.MEMPOOL.GOGGLES_INDEXING ||
@@ -45,9 +43,7 @@ export const main = sdk.setupMain(async ({ effects }) => {
     config.MEMPOOL.CPFP_INDEXING
   const backendMaxOldSpaceMB = anyIndexing
     ? Math.max(4096, Math.min(8192, Math.floor(effectiveMB / 4)))
-    : lowRam
-      ? 1024
-      : Math.max(2048, Math.min(8192, Math.floor(effectiveMB / 8)))
+    : Math.max(2048, Math.min(8192, Math.floor(effectiveMB / 8)))
 
   let backendMounts = sdk.Mounts.of()
     .mountVolume({

--- a/startos/versions/current.ts
+++ b/startos/versions/current.ts
@@ -1,18 +1,13 @@
 import { IMPOSSIBLE, VersionInfo } from '@start9labs/start-sdk'
 
 export const current = VersionInfo.of({
-  version: '3.3.1:12',
+  version: '3.3.1:13',
   releaseNotes: {
-    en_US: `- Cap the backend heap on hosts with 8 GB of RAM or less to reduce out-of-memory crashes.
-- Warn before enabling Lightning on hosts with less than 16 GB of RAM.`,
-    es_ES: `- Limita la memoria del backend en equipos con 8 GB de RAM o menos para reducir los fallos por falta de memoria.
-- Advierte antes de habilitar Lightning en equipos con menos de 16 GB de RAM.`,
-    de_DE: `- Begrenzt den Backend-Speicher auf Systemen mit 8 GB Arbeitsspeicher oder weniger, um Speichermangel-Abstuerze zu reduzieren.
-- Warnt vor dem Aktivieren von Lightning auf Systemen mit weniger als 16 GB Arbeitsspeicher.`,
-    pl_PL: `- Ogranicza pamiec backendu na urzadzeniach z 8 GB pamieci RAM lub mniej, aby zmniejszyc liczbe awarii z powodu braku pamieci.
-- Ostrzega przed wlaczeniem Lightning na urzadzeniach z mniej niz 16 GB pamieci RAM.`,
-    fr_FR: `- Limite la memoire du backend sur les hotes disposant de 8 Go de RAM ou moins pour reduire les plantages par manque de memoire.
-- Avertit avant d'activer Lightning sur les hotes disposant de moins de 16 Go de RAM.`,
+    en_US: `- Fix a startup crash on hosts with 8 GB of RAM or less: the backend heap cap was set below what the backend needs to load its disk cache, causing a JavaScript heap out-of-memory crash on every start.`,
+    es_ES: `- Corrige un fallo de inicio en equipos con 8 GB de RAM o menos: el limite de memoria del backend estaba por debajo de lo que necesita para cargar su cache en disco, provocando un fallo por falta de memoria en cada arranque.`,
+    de_DE: `- Behebt einen Startabsturz auf Systemen mit 8 GB Arbeitsspeicher oder weniger: Das Backend-Speicherlimit lag unter dem Bedarf zum Laden des Festplatten-Caches und verursachte bei jedem Start einen Speichermangel-Absturz.`,
+    pl_PL: `- Naprawia awarie uruchamiania na urzadzeniach z 8 GB pamieci RAM lub mniej: limit pamieci backendu byl nizszy niz potrzebny do zaladowania pamieci podrecznej na dysku, co powodowalo awarie z powodu braku pamieci przy kazdym starcie.`,
+    fr_FR: `- Corrige un plantage au demarrage sur les hotes disposant de 8 Go de RAM ou moins : la limite de memoire du backend etait inferieure a ce dont il a besoin pour charger son cache disque, provoquant un plantage par manque de memoire a chaque demarrage.`,
   },
   migrations: {
     up: async ({ effects }) => {},


### PR DESCRIPTION
## Problem

Follow-up to #57 and start-os#3326. PR #57 pinned the backend's V8 old-space heap to **1 GB** on hosts with <10 GB RAM, to relieve the system memory pressure that was triggering the kernel OOM-killer (which reaped Fulcrum, breaking Mempool's Electrum link).

But a heap **ceiling** below the app's working set doesn't reduce memory pressure — it just guarantees the app crashes *itself* the moment it needs more than the cap. The reporter trimmed CLN + LNbits (system RAM now ~66% used, peaks at 82%, **dmesg empty — no kernel OOM-killer**) and Mempool still crashes on every start:

```
INFO: Restoring rbf data from disk cache
<--- Last few GCs --->
[..] Mark-Compact 1019.0 (1025.1) -> 1018.7 (1029.1) MB [..] allocation failure; scavenge might not succeed
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
Unknown Error: signal: 6 (SIGABRT)
```

The backend hits the 1 GB V8 limit while restoring its mempool/rbf disk cache at startup. We converted a rare, full-stack system-OOM into a guaranteed self-OOM on every boot.

## Fix

Remove the 1 GB low-RAM down-cap. Non-indexing backends use the existing **2 GB floor** universally, which resolves to exactly 2 GB on an 8 GB host (`effectiveMB = 8192 - 6144 = 2048`). That clears the ~1 GB startup spike and non-indexing steady state, while still being bounded.

The honest position stands (and the Lightning / indexing low-RAM warnings from #57 remain): no package-side heap tuning makes Core (full) + Fulcrum + CLN + LNbits + Tor + Mempool fit in 8 GB. Strangling Mempool's heap below its working set just made Mempool the casualty instead of Fulcrum.

## Changes
- `startos/main.ts`: drop the `lowRam ? 1024` branch; comment updated to record the ceiling-vs-reservation lesson.
- Version bump `3.3.1:12` → `3.3.1:13` with release notes (edited `current.ts` in place; no new migration).

## Testing
- `tsc --noEmit` passes; prettier clean.
- Not runtime-tested on hardware — the change is a one-line heap-cap value and the failure mode (V8 heap-limit abort at ~1 GB) is unambiguous from the reporter's logs.

Closes start-os#3326 (the self-OOM regression). Resolves: Start9Labs/start-technologies#3326