### PR TITLE
ci: stop handing PR builds the signing key

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,5 +14,4 @@ jobs:
   build:
     if: github.event.pull_request.draft == false
     uses: Start9Labs/start-technologies/.github/workflows/build.yml@master
-    secrets:
-      DEV_KEY: ${{ secrets.DEV_KEY }}
+    # No DEV_KEY — a PR build doesn't publish, so it doesn't need the signing key.


### PR DESCRIPTION
From a community audit of this package (24 findings across two rounds). Only one turned into a code change here — the rest are either already fixed, or need coordinated work outside this repo. Full triage below so the analysis isn't lost.

### The change

`build.yml` no longer passes `DEV_KEY`. A PR build only compiles and packs, and `build.yml` already falls back to `start-cli init-key` when the secret is absent.

### Already fixed — the entire 16-finding 2026-08-05 round

That round was audited against the retired 0.3.x/embassy-era package. None of `start.sh`, `manifest.yaml`, `docker-entrypoint.sh` or `scripts/embassy.ts` exist in this tree, and there is no `pwgen`, `deno` or `embassyd_sdk` anywhere. Its four credential findings are all closed in the current code:

| Finding (2026-08-05) | Status in 3.3.1:21 |
|---|---|
| MariaDB reachable on TCP/3306 to other packages | `--bind-address=127.0.0.1` (`main.ts:187`) |
| Root password via weak `pwgen`, echoed to logs | `MARIADB_RANDOM_ROOT_PASSWORD: '1'` (`main.ts:189`) |
| App credentials hardcoded `mempool`/`mempool` | `getDbPassword()` at install (`init/seedFiles.ts:8`), with a migration off the old constant (`versions/v3.3.1_3.ts`) |
| Credentials `sed`-interpolated into a root-run `start.sh` | that file and the whole shell-templating path are gone |

### Confirmed, but not safe to fix here alone — dependency mounts

The 2026-08-10 round is **right**, and the CLN case is the sharp one:

- **CLN** — we mount `subpath: 'bitcoin'`, and `hsm_secret` lives in exactly that directory (`cln-startos/startos/actions/displaySeed.ts` reads `main/bitcoin/hsm_secret`). The backend only needs `bitcoin/lightning-rpc`. So a compromised backend can read the **CLN wallet seed**.
- **LND** — whole `main` volume, though only `tls.cert` and `data/chain/bitcoin/mainnet/readonly.macaroon` are used.
- **bitcoind** — whole `main` volume, though only `.cookie` is used; `wallets/` comes along with it.

Two reasons this isn't a mempool-only patch:

1. **It's fleet-wide, and mempool is already the narrowest.** Every lightning dependent — `ride-the-lightning`, `albyhub`, `lightning-terminal` — mounts `subpath: null`. Mempool is the only one that narrows at all.
2. **The naive narrowing regresses.** `.cookie` and `lightning-rpc` are unlinked and recreated when bitcoind/CLN restart. A file bind-mount pins the old inode, so mempool would keep reading a dead socket/stale cookie until it happened to restart — a silent breakage worse than the exposure, and not something I can install-test from here.

**The fix belongs provider-side.** `cln-startos` passes only `--lightning-dir`, so the socket lands next to `hsm_secret`. Giving it `--rpc-file=<dir>/rpc/lightning-rpc` puts the socket in a directory containing nothing else, which dependents can then mount as a *directory* — surviving socket recreation. bitcoind's `rpccookiefile` can move the same way. That's a coordinated change across `cln-startos`, `bitcoin-core`, and every dependent, plus migrations — worth doing, but as its own piece of work.

### Other findings, not actioned

- **`mariadb:10.4.34` is an EOL line** — correct, and worth scheduling. Moving off 10.4 is a database migration, not a tag bump.
- **Upstream CI runs untrusted PR code on self-hosted runners and publishes the images we ship** (`mempool/backend:v3.3.1`, `mempool/frontend:v3.3.1`) — correct and relevant, since we consume upstream's prebuilt images. Remediation is either building from source or accepting and pinning by digest; both are architectural.
- **Images referenced by mutable tag** — they're version tags, and `s9pk pack` embeds the image rootfs into the `.s9pk`, so every install of a given package gets byte-identical bytes under the signature and registry commitment. Build-time reproducibility only.
- **npm audit advisories** — build-time eslint tooling inside the SDK bundle; nothing on the runtime path.